### PR TITLE
Switch "today" tag to virtual "TODAY" tag

### DIFF
--- a/doc/sample-config.json
+++ b/doc/sample-config.json
@@ -11,7 +11,7 @@
 				{ "v:~:p50:p33" : [
 					"task rc.context:none summary",
 					"task rc.context:default overdue",
-					"task rc.context:none +today"
+					"task rc.context:none +TODAY"
 				] }
 			] },
 			"task burndown.daily",


### PR DESCRIPTION
Thank you for this excellent tool, I started using it today and I'm loving it.

I assume the `+today` in the example config was supposed to refer to the [virtual `+TODAY` tag](https://taskwarrior.org/docs/using_dates.html), not a literal "`+today`". This PR fixes that.